### PR TITLE
Fix dimension mismatch in Multinomial model

### DIFF
--- a/stepmix/emission/categorical.py
+++ b/stepmix/emission/categorical.py
@@ -101,7 +101,7 @@ class Multinoulli(Emission):
         return n_features
 
     def encode_features(self, X):
-        if self.integer_codes and self._cache is None:
+        if self.integer_codes:
             self._cache, self.n_outcomes = max_one_hot(X)
 
         if self.integer_codes:


### PR DESCRIPTION
Description:
This pull request fixes a dimension mismatch bug in the Multinomial class. The bug occurs when fitting a sample dataset and trying to predict another dataset with different dimensions.  Instead of predicting the new dataset, the model throws an a ValueError.

Fixes #17 

To fix the bug, I made the following changes:
* Under the encode_features function, I have deactivated the caching part as it stores the fitting dataset and ignores the predicting one.

To validate the fix, I tested the modified model class on a a training dataset for fit and testing dataset for predict and confirmed that the model now works as expected.

Please let me know if there are any further changes I can make to improve the fix.